### PR TITLE
Fix frame updates without useFrame

### DIFF
--- a/src/lib/components/Controls.svelte
+++ b/src/lib/components/Controls.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
-  import { useFrame } from '@threlte/core';
+  import * as THREE from 'three';
   import { writable } from 'svelte/store';
   import { playerState } from '../stores/gameStore';
 
@@ -73,6 +73,8 @@
     // Ajouter les écouteurs d'événements
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
+    // Démarrer la boucle de mouvement
+    frameId = requestAnimationFrame(loop);
   });
 
   onDestroy(() => {
@@ -80,6 +82,7 @@
     unsubscribePlayerState();
     window.removeEventListener('keydown', handleKeyDown);
     window.removeEventListener('keyup', handleKeyUp);
+    if (frameId) cancelAnimationFrame(frameId);
   });
 
   // Gestionnaire de mouvement
@@ -107,10 +110,17 @@
     }
   }
 
-  // Appliquer le mouvement à chaque frame
-  useFrame(() => {
+  // Boucle de rendu pour appliquer le mouvement
+  const clock = new THREE.Clock();
+  let frameId;
+
+  function loop() {
+    clock.getDelta(); // avance le temps
     handleMovement();
-  });
+    frameId = requestAnimationFrame(loop);
+  }
+
+  // le démarrage et l'arrêt de la boucle sont gérés plus haut
 </script>
 
 <!-- Ce composant ne rend rien visuellement, il gère uniquement les contrôles -->

--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { useThrelte, useFrame } from '@threlte/core';
-  import { RigidBody } from '@threlte/rapier';
-  import { onMount } from 'svelte';
+import { useThrelte } from '@threlte/core';
+import { RigidBody } from '@threlte/rapier';
+import { onMount, onDestroy } from 'svelte';
   import * as THREE from 'three';
   import { writable } from 'svelte/store';
   import { playerState } from '../stores/gameStore';
@@ -37,8 +37,11 @@
     }
   });
 
-  // Mettre à jour le joueur à chaque frame
-  useFrame((state, delta) => {
+  // Boucle de mise à jour du joueur
+  const clock = new THREE.Clock();
+  let frameId;
+
+  function updatePlayer(delta) {
     if (!rigidBodyInstance) return;
 
     // Récupération de la position actuelle
@@ -68,6 +71,20 @@
         rigidBody: rigidBodyInstance
       });
     }
+  }
+
+  function loop() {
+    const delta = clock.getDelta();
+    updatePlayer(delta);
+    frameId = requestAnimationFrame(loop);
+  }
+
+  onMount(() => {
+    frameId = requestAnimationFrame(loop);
+  });
+
+  onDestroy(() => {
+    if (frameId) cancelAnimationFrame(frameId);
   });
 
   // Fonction pour appliquer le saut


### PR DESCRIPTION
## Summary
- remove custom `useFrame` helper
- drive frame updates using a simple `requestAnimationFrame` loop in `Controls.svelte` and `Player.svelte`

## Testing
- `npm install --silent` *(fails: no network)*